### PR TITLE
Clear error flags on a serial read

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -324,20 +324,40 @@ macro_rules! usart {
                     // NOTE(unsafe) atomic read with no side effects
                     let sr = unsafe { (*$USARTX::ptr()).sr.read() };
 
-                    Err(if sr.pe().bit_is_set() {
-                        nb::Error::Other(Error::Parity)
+                    // Check for any errors
+                    let err = if sr.pe().bit_is_set() {
+                        Some(Error::Parity)
                     } else if sr.fe().bit_is_set() {
-                        nb::Error::Other(Error::Framing)
+                        Some(Error::Framing)
                     } else if sr.nf().bit_is_set() {
-                        nb::Error::Other(Error::Noise)
+                        Some(Error::Noise)
                     } else if sr.ore().bit_is_set() {
-                        nb::Error::Other(Error::Overrun)
-                    } else if sr.rxne().bit_is_set() {
-                        // NOTE(read_volatile) see `write_volatile` below
-                        return Ok(unsafe { ptr::read_volatile(&(*$USARTX::ptr()).dr as *const _ as *const _) });
+                        Some(Error::Overrun)
                     } else {
-                        nb::Error::WouldBlock
-                    })
+                        None
+                    };
+
+                    if let Some(err) = err {
+                        // Some error occured. In order to clear that error flag, you have to
+                        // do a read from the sr register followed by a read from the dr register
+                        // NOTE(read_volatile) see `write_volatile` below
+                        unsafe {
+                            ptr::read_volatile(&(*$USARTX::ptr()).sr as *const _ as *const _);
+                            ptr::read_volatile(&(*$USARTX::ptr()).dr as *const _ as *const _);
+                        }
+                        Err(nb::Error::Other(err))
+                    } else {
+                        // Check if a byte is available
+                        if sr.rxne().bit_is_set() {
+                            // Read the received byte
+                            // NOTE(read_volatile) see `write_volatile` below
+                            Ok(unsafe {
+                                ptr::read_volatile(&(*$USARTX::ptr()).dr as *const _ as *const _)
+                            })
+                        } else {
+                            Err(nb::Error::WouldBlock)
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
According to the "*27.6.1 Status register (USART_SR)*" in case if error flag bit is set during the read, software needs to clear it by reading SR and DR registers.

Basically it is a copy of the `stm32f1xx-hal` lib `Serial::read` implementation: https://github.com/stm32-rs/stm32f1xx-hal/blob/e36195ed3ea4512ffe5fa0683d7cc510e54cc4b5/src/serial.rs#L348-L388 , but since I'm not an expert in an embedded field, it would be nice to check it once again.