### PR TITLE
i2c/examples: updates and fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ panic-semihosting = "0.5.1"
 cortex-m-rtfm = "0.4.2"
 
 [features]
-default = ["rt", "stm32l162"]
 rt = ["stm32l1/rt"]
 stm32l100 = ["stm32l1/stm32l100"]
 stm32l151 = ["stm32l1/stm32l151"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,7 @@ incremental = false
 codegen-units = 1
 debug = true
 lto = true
+
+[[example]]
+name = "button_irq"
+required-features = ["rt"]

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -8,6 +8,7 @@ extern crate cortex_m_rt as rt;
 extern crate stm32l1xx_hal as hal;
 
 use core::panic::PanicInfo;
+use embedded_hal::digital::v2::OutputPin;
 use hal::prelude::*;
 use hal::stm32;
 use rt::entry;
@@ -20,10 +21,10 @@ fn main() -> ! {
 
     loop {
         for _ in 0..1_000 {
-            led.set_high();
+            led.set_high().unwrap();
         }
         for _ in 0..1_000 {
-            led.set_low();
+            led.set_low().unwrap();
         }
     }
 }

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -8,6 +8,7 @@ extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 extern crate stm32l1xx_hal as hal;
 
+use embedded_hal::digital::v2::ToggleableOutputPin;
 use hal::prelude::*;
 use hal::rcc::Config;
 use hal::stm32;
@@ -25,7 +26,7 @@ fn main() -> ! {
     let mut led = gpiob.pb6.into_push_pull_output();
 
     loop {
-        led.toggle();
+        led.toggle().unwrap();
         delay.delay(300.ms());
     }
 }

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -9,6 +9,7 @@ extern crate nb;
 extern crate panic_semihosting;
 extern crate stm32l1xx_hal as hal;
 
+use embedded_hal::digital::v2::ToggleableOutputPin;
 use hal::prelude::*;
 use hal::rcc::Config;
 use hal::stm32;
@@ -27,7 +28,7 @@ fn main() -> ! {
     let mut timer = dp.TIM2.timer(2.hz(), &mut rcc);
 
     loop {
-        led.toggle();
+        led.toggle().unwrap();
         block!(timer.wait()).unwrap();
     }
 }

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -8,6 +8,8 @@ extern crate cortex_m_rt as rt;
 extern crate panic_semihosting;
 extern crate stm32l1xx_hal as hal;
 
+use embedded_hal::digital::v2::InputPin;
+use embedded_hal::digital::v2::OutputPin;
 use hal::prelude::*;
 use hal::rcc::Config;
 use hal::stm32;
@@ -28,11 +30,11 @@ fn main() -> ! {
     let mut led = gpiob.pb6.into_push_pull_output();
 
     loop {
-        if button.is_high() {
-            led.set_high();
+        if button.is_high().unwrap() {
+            led.set_high().unwrap();
             delay.delay(500.ms());
         } else {
-            led.set_low();
+            led.set_low().unwrap();
         }
     }
 }

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 #![no_main]
 #![no_std]
-#![feature(custom_attribute)]
 
 extern crate cortex_m;
 extern crate cortex_m_rt as rt;
@@ -13,6 +12,8 @@ extern crate stm32l1xx_hal as hal;
 use cortex_m_semihosting::hprintln;
 use rtfm::app;
 
+use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::v2::ToggleableOutputPin;
 use hal::exti::TriggerEdge;
 use hal::gpio::gpiob::{PB6, PB7};
 use hal::gpio::{Output, PushPull};
@@ -49,15 +50,15 @@ const APP: () = {
     fn TIM2() {
         *resources.DELTA += 1;
 
-        resources.TICKS_LED.toggle();
+        resources.TICKS_LED.toggle().unwrap();
         resources.TIMER.clear_irq();
     }
 
     #[interrupt(resources = [EXTI, BUSY_LED, DELTA])]
     fn EXTI0() {
-        resources.BUSY_LED.set_high();
+        resources.BUSY_LED.set_high().unwrap();
         hprintln!("Δ: {}", resources.DELTA).unwrap();
-        resources.BUSY_LED.set_low();
+        resources.BUSY_LED.set_low().unwrap();
 
         *resources.DELTA = 0;
         resources.EXTI.clear_irq(0);

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -13,6 +13,7 @@ use core::fmt::Write;
 use hal::prelude::*;
 use hal::rcc::Config;
 use hal::serial;
+use hal::serial::SerialExt;
 use hal::stm32;
 use nb::block;
 use rt::entry;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -210,8 +210,15 @@ macro_rules! i2c {
                 bytes: &[u8],
                 buffer: &mut [u8],
             ) -> Result<(), Self::Error> {
-                self.write_bytes(addr, bytes)?;
-                self.read(addr, buffer)?;
+                if !bytes.is_empty() {
+                    self.write_bytes(addr, bytes)?;
+                }
+
+                if !buffer.is_empty() {
+                    self.read(addr, buffer)?;
+                } else if !bytes.is_empty() {
+                    self.i2c.cr1.modify(|_, w| w.stop().set_bit());
+                }
 
                 Ok(())
             }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,7 +1,7 @@
 //! I2C
 use hal::blocking::i2c::{Read, Write, WriteRead};
 
-use crate::gpio::gpiob::{PB10, PB11, PB6, PB7};
+use crate::gpio::gpiob::{PB10, PB11, PB6, PB7, PB8, PB9};
 use crate::gpio::{AltMode, OpenDrain, Output};
 use crate::prelude::*;
 use crate::rcc::Rcc;
@@ -19,6 +19,13 @@ pub trait Pins<I2c> {
 }
 
 impl Pins<I2C1> for (PB6<Output<OpenDrain>>, PB7<Output<OpenDrain>>) {
+    fn setup(&self) {
+        self.0.set_alt_mode(AltMode::I2C);
+        self.1.set_alt_mode(AltMode::I2C);
+    }
+}
+
+impl Pins<I2C1> for (PB8<Output<OpenDrain>>, PB9<Output<OpenDrain>>) {
     fn setup(&self) {
         self.0.set_alt_mode(AltMode::I2C);
         self.1.set_alt_mode(AltMode::I2C);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -225,47 +225,56 @@ macro_rules! i2c {
             type Error = Error;
 
             fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
-                // Send a START condition and set ACK bit
-                self.i2c
-                    .cr1
-                    .modify(|_, w| w.start().set_bit().ack().set_bit());
+                if let Some((last, buffer)) = buffer.split_last_mut() {
+                    // Send a START condition and set ACK bit
+                    self.i2c
+                        .cr1
+                        .modify(|_, w| w.start().set_bit().ack().set_bit());
 
-                // Wait until START condition was generated
-                while {
-                    let sr1 = self.i2c.sr1.read();
-                    sr1.sb().bit_is_clear()
-                } {}
+                    // Wait until START condition was generated
+                    while {
+                        let sr1 = self.i2c.sr1.read();
+                        sr1.sb().bit_is_clear()
+                    } {}
 
-                // Also wait until signalled we're master and everything is waiting for us
-                while {
-                    let sr2 = self.i2c.sr2.read();
-                    sr2.msl().bit_is_clear() && sr2.busy().bit_is_clear()
-                } {}
+                    // Also wait until signalled we're master and everything is waiting for us
+                    while {
+                        let sr2 = self.i2c.sr2.read();
+                        sr2.msl().bit_is_clear() && sr2.busy().bit_is_clear()
+                    } {}
 
-                // Set up current address, we're trying to talk to
-                self.i2c
-                    .dr
-                    .write(|w| unsafe { w.bits((u32::from(addr) << 1) + 1) });
+                    // Set up current address, we're trying to talk to
+                    self.i2c
+                        .dr
+                        .write(|w| unsafe { w.bits((u32::from(addr) << 1) + 1) });
 
-                // Wait until address was sent
-                while {
-                    let sr1 = self.i2c.sr1.read();
-                    sr1.addr().bit_is_clear()
-                } {}
+                    // Wait until address was sent
+                    while {
+                        let sr1 = self.i2c.sr1.read();
+                        sr1.addr().bit_is_clear()
+                    } {}
 
-                // Clear condition by reading SR2
-                self.i2c.sr2.read();
+                    // Clear condition by reading SR2
+                    self.i2c.sr2.read();
 
-                // Receive bytes into buffer
-                for c in buffer {
-                    *c = self.recv_byte()?;
+                    // Receive bytes into buffer
+                    for c in buffer {
+                        *c = self.recv_byte()?;
+                    }
+
+                    // Prepare to send NACK then STOP after next byte
+                    self.i2c
+                        .cr1
+                        .modify(|_, w| w.ack().clear_bit().stop().set_bit());
+
+                    // Receive last byte
+                    *last = self.recv_byte()?;
+
+                    // Fallthrough is success
+                    Ok(())
+                } else {
+                    Err(Error::OVERRUN)
                 }
-
-                // Send STOP condition
-                self.i2c.cr1.modify(|_, w| w.stop().set_bit());
-
-                // Fallthrough is success
-                Ok(())
             }
         }
 


### PR DESCRIPTION
Hi @dotcypress, @hdhoang  and all,

This PR includes several changes that can be grouped into the following two sets:
* fixes for building crate and examples
  * remove default feature to force proper MCU selection and to avoid build issues when default features are not disabled
* updates and fixes for i2c implementation
  * add more I2C pins
  * fix read operations: set NACK before last read
  * fix write operations: set STOP after last write when necessary

Regards,
Sergey