### PR TITLE
ADC updates: enable reading VRef and VTemp

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,0 +1,43 @@
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate cortex_m;
+extern crate cortex_m_rt as rt;
+extern crate panic_semihosting;
+extern crate stm32l1xx_hal as hal;
+
+use hal::adc::Precision;
+use hal::adc::VRef;
+use hal::prelude::*;
+use hal::rcc::Config;
+use hal::stm32;
+use rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let mut rcc = dp.RCC.freeze(Config::hsi());
+    let gpioa = dp.GPIOA.split();
+
+    let mut adc = dp.ADC.adc(&mut rcc);
+    adc.set_precision(Precision::B_12);
+
+    let mut chan = gpioa.pa0.into_analog();
+    let mut vref = VRef::new();
+
+    let vref_cal: u16 = VRef::get_vrefcal();
+    /* scale for 12-bit range */
+    let scale = 4095;
+
+    vref.enable(&mut adc);
+
+    loop {
+        let chan_val: u16 = adc.read(&mut chan).unwrap();
+        let vref_val: u16 = adc.read(&mut vref).unwrap();
+
+        let _absolute_voltage = 3 * vref_cal * chan_val / vref_val / scale;
+    }
+}

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -182,6 +182,11 @@ adc_pins! {
     Channel12b: (gpiog::PG4<Analog>, true, 12_u8, smpr2),
 }
 
+adc_pins! {
+    Channel16: (VTemp, false, 16_u8, smpr2),
+    Channel17: (VRef, false, 17_u8, smpr2),
+}
+
 impl VTemp {
     /// Init a new VTemp
     pub fn new() -> Self {
@@ -213,22 +218,6 @@ impl VRef {
     /// Disable the internal reference voltage.
     pub fn disable(&mut self, adc: &mut Adc) {
         adc.rb.ccr.modify(|_, w| w.tsvrefe().clear_bit());
-    }
-}
-
-impl Channel<Adc> for VTemp {
-    type ID = u8;
-
-    fn channel() -> u8 {
-        16
-    }
-}
-
-impl Channel<Adc> for VRef {
-    type ID = u8;
-
-    fn channel() -> u8 {
-        17
     }
 }
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -2,7 +2,10 @@
 use crate::gpio::*;
 use crate::rcc::Rcc;
 use crate::stm32::ADC;
+use core::ptr;
 use hal::adc::{Channel, OneShot};
+
+const VREFCAL: *const u16 = 0x1FF8_0078 as *const u16;
 
 /// Analog to Digital converter interface
 pub struct Adc {
@@ -208,6 +211,10 @@ impl VRef {
     /// Init a new VRef
     pub fn new() -> Self {
         VRef {}
+    }
+
+    pub fn get_vrefcal() -> u16 {
+        u16::from(unsafe { ptr::read(VREFCAL) })
     }
 
     /// Enable the internal voltage reference, remember to disable when not in use.


### PR DESCRIPTION
Hi @dotcypress , @hdhoang  and all

This PR includes several fixes and minor improvements for ADC:
* Enable reading VRef and VTemp
  These two structures are supposed to behave like any other normal channel. So, in order to enable reading from channel, both should implement AdcChannel trait.

* Enable access to calibration data for internal reference voltage
  VREFINT_CAL values are acquired during the manufacturing process and stored in a specific data address

* Add new adc example
  how to use VREFINT readings and VREFINT_CAL values to calculate absolute voltage values

Regards,
Sergey