### PR TITLE
Update stm32l1 crate to v0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ repository = "https://github.com/stm32-rs/stm32l1xx-hal"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.5.8"
+cortex-m = "0.6.3"
 nb = "0.1.1"
-stm32l1 = "0.5.0"
+stm32l1 = "0.7.1"
 
 [dependencies.bare-metal]
 features = ["const-fn"]
@@ -35,7 +35,7 @@ version = "0.2.2"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
-version = "0.2.3"
+version = "0.2.4"
 
 [dependencies.void]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.1.0"
 [dependencies]
 cortex-m = "0.6.3"
 nb = "0.1.1"
-stm32l1 = "0.8.0"
+stm32l1 = "0.12.1"
 
 [dependencies.bare-metal]
 features = ["const-fn"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.1.0"
 [dependencies]
 cortex-m = "0.6.3"
 nb = "0.1.1"
-stm32l1 = "0.7.1"
+stm32l1 = "0.8.0"
 
 [dependencies.bare-metal]
 features = ["const-fn"]

--- a/examples/button_irq.rs
+++ b/examples/button_irq.rs
@@ -23,9 +23,11 @@ static INT: Mutex<RefCell<Option<EXTI>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
-    let mut cp = cortex_m::Peripherals::take().unwrap();
 
-    cp.NVIC.enable(Interrupt::EXTI0);
+    unsafe {
+        cortex_m::peripheral::NVIC::unmask(Interrupt::EXTI0);
+    }
+
     dp.EXTI.listen(0, TriggerEdge::Falling);
 
     cortex_m::interrupt::free(move |cs| {

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -23,13 +23,14 @@ static TIMER: Mutex<RefCell<Option<Timer<stm32::TIM2>>>> = Mutex::new(RefCell::n
 #[entry]
 fn main() -> ! {
     let dp = stm32::Peripherals::take().unwrap();
-    let mut cp = cortex_m::Peripherals::take().unwrap();
     let mut rcc = dp.RCC.freeze(Config::hsi());
 
     let mut timer = dp.TIM2.timer(1.hz(), &mut rcc);
     timer.listen();
 
-    cp.NVIC.enable(Interrupt::TIM2);
+    unsafe {
+        cortex_m::peripheral::NVIC::unmask(Interrupt::TIM2);
+    }
 
     cortex_m::interrupt::free(move |cs| {
         *TIMER.borrow(cs).borrow_mut() = Some(timer);

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -54,7 +54,7 @@ macro_rules! channels {
             fn enable(&mut self) {
                 unsafe {
                     let tim = &*$TIMX::ptr();
-                    tim.ccmr1_output
+                    tim.ccmr1_output()
                         .modify(|_, w| w.oc1pe().set_bit().oc1m().bits(6));
                     tim.ccer.modify(|_, w| w.cc1e().set_bit());
                 }
@@ -137,7 +137,7 @@ macro_rules! channels {
             fn enable(&mut self) {
                 unsafe {
                     let tim = &*$TIMX::ptr();
-                    tim.ccmr1_output
+                    tim.ccmr1_output()
                         .modify(|_, w| w.oc2pe().set_bit().oc2m().bits(6));
                     tim.ccer.modify(|_, w| w.cc2e().set_bit());
                 }
@@ -168,7 +168,7 @@ macro_rules! channels {
             fn enable(&mut self) {
                 unsafe {
                     let tim = &*$TIMX::ptr();
-                    tim.ccmr2_output
+                    tim.ccmr2_output()
                         .modify(|_, w| w.oc3pe().set_bit().oc3m().bits(6));
                     tim.ccer.modify(|_, w| w.cc3e().set_bit());
                 }
@@ -199,7 +199,7 @@ macro_rules! channels {
             fn enable(&mut self) {
                 unsafe {
                     let tim = &*$TIMX::ptr();
-                    tim.ccmr2_output
+                    tim.ccmr2_output()
                         .modify(|_, w| w.oc4pe().set_bit().oc4m().bits(6));
                     tim.ccer.modify(|_, w| w.cc4e().set_bit());
                 }
@@ -257,7 +257,7 @@ macro_rules! timers {
                 let ticks = clk / freq;
                 let psc = u16((ticks - 1) / (1 << 16)).unwrap();
                 let arr = u16(ticks / u32(psc + 1)).unwrap();
-                tim.psc.write(|w| unsafe { w.psc().bits(psc) });
+                tim.psc.write(|w| w.psc().bits(psc) );
                 #[allow(unused_unsafe)]
                 tim.arr.write(|w| unsafe { w.arr().bits(arr) });
                 tim.cr1.write(|w| w.cen().set_bit());

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -61,7 +61,7 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).ccr1.read().ccr1().bits() }
+                unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() }
             }
 
             fn get_max_duty(&self) -> u16 {
@@ -69,7 +69,7 @@ macro_rules! channels {
             }
 
             fn set_duty(&mut self, duty: u16) {
-                unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr1().bits(duty)) }
+                unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty)) }
             }
         }
     };
@@ -144,7 +144,7 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).ccr2.read().ccr2().bits() }
+                unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() }
             }
 
             fn get_max_duty(&self) -> u16 {
@@ -152,7 +152,7 @@ macro_rules! channels {
             }
 
             fn set_duty(&mut self, duty: u16) {
-                unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr2().bits(duty)) }
+                unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty)) }
             }
         }
 
@@ -175,7 +175,7 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).ccr3.read().ccr3().bits() }
+                unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() }
             }
 
             fn get_max_duty(&self) -> u16 {
@@ -183,7 +183,7 @@ macro_rules! channels {
             }
 
             fn set_duty(&mut self, duty: u16) {
-                unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr3().bits(duty)) }
+                unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty)) }
             }
         }
 
@@ -206,7 +206,7 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).ccr4.read().ccr4().bits() }
+                unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() }
             }
 
             fn get_max_duty(&self) -> u16 {
@@ -214,7 +214,7 @@ macro_rules! channels {
             }
 
             fn set_duty(&mut self, duty: u16) {
-                unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr4().bits(duty)) }
+                unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty)) }
             }
         }
     };

--- a/src/qei.rs
+++ b/src/qei.rs
@@ -63,7 +63,7 @@ macro_rules! hal {
                     rcc.rb.apb1rstr.modify(|_, w| w.$timXrst().clear_bit());
 
                     // Configure TxC1 and TxC2 as captures
-                    tim.ccmr1_output.write(|w| unsafe {
+                    tim.ccmr1_output().write(|w| unsafe {
                         w.cc1s().bits(0b01).cc2s().set_bit()
                     });
 
@@ -84,7 +84,7 @@ macro_rules! hal {
                     });
 
                     // Encoder mode, count up/down on both TI1FP1 and TI2FP2
-                    tim.smcr.write(|w| unsafe { w.sms().bits(0b011) });
+                    tim.smcr.write(|w| w.sms().bits(0b011) );
 
                     tim.arr.write(|w| w.arr().bits(u16::MAX));
                     tim.cr1.write(|w| w.cen().enabled());

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -151,7 +151,7 @@ macro_rules! timers {
                     let ticks = self.clocks.$timclk().0 / freq;
                     let psc = u16((ticks - 1) / (1 << 16)).unwrap();
 
-                    self.tim.psc.write(|w| unsafe { w.psc().bits(psc) });
+                    self.tim.psc.write(|w| w.psc().bits(psc) );
                     self.tim.arr.write(|w| unsafe { w.bits(ticks / u32(psc + 1)) });
 
                     self.tim.cr1.modify(|_, w| w.urs().set_bit());


### PR DESCRIPTION
Hi, merging this would update the crate stm32l1 along with minor updates to couple of examples to make them compile. The cortex-m and embedded-l versions are also brought up a bit.